### PR TITLE
Enable static lib build to fix xapian-config on OSX

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - zlib
 
 test:
-  commands: xapian-config --version
+  commands: xapian-config --cxxflags --ltlibs  # required by lang bindings
 
 about:
   home: http://xapian.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,8 @@ build:
     --prefix=$PREFIX \
     CXXFLAGS=-I$PREFIX/include
 
-    make && make install prefix=$PREFIX
+    make -j ${CPU_COUNT}
+    make install prefix=$PREFIX
     rm -rf $PREFIX/share/doc/xapian-core
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "1.4.15" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -16,32 +16,26 @@ build:
     LDFLAGS=$LDFLAGS \
     ./configure \
     --enable-static \
-    CXXFLAGS=-I$PREFIX/include \
-    --prefix=$PREFIX
+    --enable-shared \
+    --disable-documentation \
+    --prefix=$PREFIX \
+    CXXFLAGS=-I$PREFIX/include
 
     make && make install prefix=$PREFIX
     rm -rf $PREFIX/share/doc/xapian-core
 
-  run_exports: {{ pin_subpackage('xapian-core', max_pin='x.x.x') }}
-
 requirements:
   build:
     - {{ compiler('cxx') }}
-
   host:
     - zlib
 
 test:
-  requires:
-    - libtool
   commands:
     - test -f ${PREFIX}/lib/libxapian.a
-    - test -f ${PREFIX}/lib/libxapian.la
     - test -f ${PREFIX}/lib/libxapian.so # [linux]
     - test -f ${PREFIX}/lib/libxapian.dylib # [osx]
-    - |
-      LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH \
-      xapian-config --cxxflags --ltlibs  # command used by language bindings
+    - xapian-config --cxxflags --libs  # command used by language bindings
 
 about:
   home: http://xapian.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
     CXXFLAGS=-I$PREFIX/include \
     --prefix=$PREFIX
 
-    make && make install
+    make && make install prefix=$PREFIX
     rm -rf $PREFIX/share/doc/xapian-core
 
   run_exports: {{ pin_subpackage('xapian-core', max_pin='x.x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,12 @@ source:
   sha256: b168e95918a01e014fb6a6cbce26e535f80da4d4791bfa5a0e0051fcb6f950ea
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   script: |
     LDFLAGS=$LDFLAGS \
     ./configure \
+    --enable-static \
     CXXFLAGS=-I$PREFIX/include \
     --prefix=$PREFIX
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,9 @@ requirements:
     - zlib
 
 test:
-  commands: xapian-config --cxxflags --ltlibs  # required by lang bindings
+  commands: |
+    LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH \
+    xapian-config --cxxflags --ltlibs  # command used by language bindings
 
 about:
   home: http://xapian.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,8 +34,8 @@ requirements:
 test:
   commands:
     - test -f ${PREFIX}/lib/libxapian.a
-    - test -f ${PREFIX}/lib/libxapian.so # [linux]
-    - test -f ${PREFIX}/lib/libxapian.dylib # [osx]
+    - test -f ${PREFIX}/lib/libxapian.so  # [linux]
+    - test -f ${PREFIX}/lib/libxapian.dylib  # [osx]
     - xapian-config --cxxflags --libs  # command used by language bindings
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,9 +32,16 @@ requirements:
     - zlib
 
 test:
-  commands: |
-    LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH \
-    xapian-config --cxxflags --ltlibs  # command used by language bindings
+  requires:
+    - libtool
+  commands:
+    - test -f ${PREFIX}/lib/libxapian.a
+    - test -f ${PREFIX}/lib/libxapian.la
+    - test -f ${PREFIX}/lib/libxapian.so # [linux]
+    - test -f ${PREFIX}/lib/libxapian.dylib # [osx]
+    - |
+      LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH \
+      xapian-config --cxxflags --ltlibs  # command used by language bindings
 
 about:
   home: http://xapian.org


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
